### PR TITLE
places search in trip planner + bug fix

### DIFF
--- a/app/static/js/common.js
+++ b/app/static/js/common.js
@@ -60,7 +60,7 @@ function error(err) {
 
 
 //Generate the map and event listeners using lat and lon, set map center to user's location.
-function mapGenerator(coords, skipMarker) {
+function mapGenerator(coords) {
     var mapOptions = {
         center: new google.maps.LatLng(coords[0], coords[1]),
         zoom: 14,
@@ -74,7 +74,6 @@ function mapGenerator(coords, skipMarker) {
 
     //Generate markers and search box.
     markerGenerator(map);
-    searchboxGenerator(map);
 
     return map;
 
@@ -131,13 +130,27 @@ function removeMarkers(deleteMarkers) {
     }
 }
 
-//Add searchbox to map. When place is selected, add markers and lat and lon to form.
-function searchboxGenerator(map) {
-    var markers = [];
+// Adds places search to an input. If needed, positions the searchbox in the top-left of its parent.
+// opt_setLatLon: Optional boolean used in index and report map views.
+function searchBoxGenerator(searchBoxSelector, opt_setLatLon) {
     // Create the search box and link it to the UI element.
-    var input = document.getElementById('pac-input');
-    map.controls[google.maps.ControlPosition.TOP_LEFT].push(input);
-    var searchBox = new google.maps.places.SearchBox(input);
+    var placesInputs = $(searchBoxSelector);
+    var searchBoxes = [];
+
+    for (var a = 0; a < placesInputs.length; a++) {
+        var searchBox = new google.maps.places.SearchBox(placesInputs[a]);
+        searchBoxes.push(searchBox);
+    }
+
+    if (opt_setLatLon) {
+        searchBoxSetLatLon(searchBoxes);
+    }
+}
+
+// Set a latitude and longitude on the map for index and report map views.
+function searchBoxSetLatLon(searchBoxes){
+    var markers = [];
+    var searchBox = searchBoxes[0];
 
     // Listen for the event fired when the user selects an item from the
     // pick list. Retrieve the matching places for that item.
@@ -152,7 +165,6 @@ function searchboxGenerator(map) {
         }
 
         // For each place, get the icon, place name, and location.
-        // markers = [];
         var bounds = new google.maps.LatLngBounds();
         for (var i = 0, place; place = places[i]; i++) {
             var image = {
@@ -183,7 +195,6 @@ function searchboxGenerator(map) {
             return setFormLatLon(lat, lon, '#id_lat', '#id_lon');
         }
     });
-
 }
 
 //Set latitude and longitude in forms.
@@ -198,11 +209,9 @@ function setFormLatLon(lat, lon, element1, element2) {
     return true;
 }
 
-// Convert coordinates to an address (coords must be an array [lat, lon]).
-function coordsToAddress(coords) {
-    var test = httpGet('https://maps.googleapis.com/maps/api/geocode/json?latlng=' + coords[0] + ',' + coords[1]);
-
-    return test;
+// Special numeric sort function to account for negative values.
+function compareNumbers(a, b) {
+  return a - b;
 }
 
 //Get data from API to generate markers.

--- a/app/static/js/report_map.js
+++ b/app/static/js/report_map.js
@@ -6,6 +6,7 @@ $(document).ready(function () {
 // Run these functions after setting geolocation. All except setFormDateTime() are dependent on geolocation to run.
 initGeolocation().then(function (coords) {
     map = mapGenerator(coords);
+    searchBoxGenerator('#pac-input', true);
     setFormLatLon(coords[0], coords[1], '#id_lat', '#id_lon');
     setFormListeners();
     setFormDateTime();

--- a/app/static/js/view_map.js
+++ b/app/static/js/view_map.js
@@ -6,4 +6,5 @@ $(document).ready(function () {
 // Run these functions after setting geolocation. All except setFormDateTime() are dependent on geolocation to run.
 initGeolocation().then(function (coords) {
     map = mapGenerator(coords);
+    searchBoxGenerator('#pac-input', true);
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -62,12 +62,10 @@
 
 
 	<!-- Placed at the end of the document so the pages load faster -->
-
 	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBYj-5SiLbT7Ssu4c4q2nUIUZK4Q3lJYFI&sensor=true&libraries=places"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}js/foundation.min.js"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}js/foundation.reveal.js"></script>
 	<script>$(document).foundation();</script>
-
 
 	{# For loading scripts at the bottom of the view. #}
 	{% block scripts_bottom %}

--- a/app/templates/trip_planner.html
+++ b/app/templates/trip_planner.html
@@ -18,11 +18,13 @@
 				<div id="trip-planner-form" class="slider">
 					<div class="medium-4 columns">
 						<label>Start: </label>
-						<input id="start" class="trip-planner-form" type="text">
+						<input id="start" class="trip-planner-form places-input"
+							   type="text" placeholder="Search for a location">
 					</div>
 					<div class="medium-4 columns">
 						<label>End: </label>
-						<input id="end" class="trip-planner-form" type="text">
+						<input id="end" class="trip-planner-form places-input"
+							   type="text" placeholder="Search for a location">
 					</div>
 					<div class="medium-4 columns">
 						<label>Mode of Travel: </label>
@@ -39,9 +41,6 @@
 			</div>
 		</div>
 		<div class="medium-12 columns">
-			<!-- TODO(zemadi): Add places search. -->
-			<input id="pac-input" class="controls" type="text"
-				   placeholder="Places search is currently disabled. We'll add this feature soon!">
 			<div id="map-canvas" class="edit-form-map"></div>
 			<div id="directions-panel"></div>
 		</div>


### PR DESCRIPTION
Fixes three issues:
1) Bug that breaks trip planner JS -- the keys for the response object returned by the google directions API change. Because the keys are hardcoded in our js, this results in KeyErrors. This new code changes the way that the directions response is processed so it keys aren't hard-coded. 

2) Improved the way that the api query string is built. The query needs to look for records with values between the route's max latitude and longitude. The api doesn't have a BETWEEN lookup, so it has to use greater than/less than. Looking for a number between two values is a shorter way of saying get values greater than x but less than y. Because coordinates can have negative values, this results in some weird code to build a query string. 

The solution is to sort the values before building the query string. That way, you always know that the smaller value is at index 0 and the larger at index 1. 

3) Added places search into trip planner form inputs, which is issue #16: https://github.com/CycleSafe/CycleSafe_deploy/issues/16

Thanks!
