### PR TITLE
Http request warning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,26 @@
+#General
+*.swp
+*.DS_Store
+
+#Python
 venv
 *.pyc
+
+#Sqlite3
 db.sqlite3
-*.idea
-app/migrations/*
 *.sqlite3
+
+#IntelliJ
+*.idea
 .idea
+
+#CycleSafe App
+app/migrations/*
 local_settings.py
 local_settings_old.py
+
+#SASS Cache
+.sass-cache/
+
+#NPM Modules
+node_modules/

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -62,12 +62,10 @@
 
 
 	<!-- Placed at the end of the document so the pages load faster -->
-
 	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBYj-5SiLbT7Ssu4c4q2nUIUZK4Q3lJYFI&sensor=true&libraries=places"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}js/foundation.min.js"></script>
 	<script type="text/javascript" src="{{ STATIC_URL }}js/foundation.reveal.js"></script>
 	<script>$(document).foundation();</script>
-
 
 	{# For loading scripts at the bottom of the view. #}
 	{% block scripts_bottom %}

--- a/cyclesafe/settings.py
+++ b/cyclesafe/settings.py
@@ -29,8 +29,8 @@ ROOT_PATH = os.path.dirname(__file__)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Turned off debugging.
-DEBUG = True
-TEMPLATE_DEBUG = True
+DEBUG = False
+TEMPLATE_DEBUG = False
 
 # Application definition
 INSTALLED_APPS = (
@@ -120,8 +120,6 @@ TEMPLATE_LOADERS = ('django.template.loaders.filesystem.Loader', 'django.templat
 # Media_url specifies the location of user-uploaded files.
 MEDIA_URL = '/static/media/'
 STATIC_URL = '/static/'
-# NOTE: The STATIC_ROOT directory is where staticfiles need to be stored. This may need to be changed depending on
-# OpenShift's requirements.
 STATIC_ROOT = os.path.join(PROJECT_DIR, '..', 'static')
 
 STATICFILES_FINDERS = (


### PR DESCRIPTION
Quick fix to convert our http requests to asynchronous. It's why we get this warning: 'Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience.'

This fix uses callbacks and .bind() instead of promises because it isn't fully supported for mobile browsers. 

Thanks!
