### PR TITLE
limit queries to within map bounds

### DIFF
--- a/app/static/js/common.js
+++ b/app/static/js/common.js
@@ -90,7 +90,8 @@ function mapGenerator(coords) {
     // it doesn't need a DB query either.
     google.maps.event.addListener(map, 'zoom_changed', function() {
         var newZoomLevel = map.getZoom();
-        // If the zoom level is in the list of valid zoom levels, get new marker data.
+        // If the zoom level is in the list of valid levels and if the user zooms out, get new marker data.
+        // We determine if a user has zoomed out by comparing the old and new zoom levels.
         if (zoomOutLevels.indexOf(newZoomLevel) > -1 && currentZoomLevel > newZoomLevel) {
           getMarkerData(map);
         };

--- a/app/static/js/trip_planner.js
+++ b/app/static/js/trip_planner.js
@@ -79,7 +79,7 @@ function getMarkers(directionsResponse){
     }
 
     // Build the query string, limiting the results for cyclists and pedestrians.
-    var queryString = '/api/v1/hazard/?format=json&user_type=' + userType;
+    var queryString = baseQueryString +'&user_type=' + userType;
 
     // Get the maximum and minimum lat/lon bounds for the route.
     // This will narrow the query to a box around the route as a whole.
@@ -101,19 +101,6 @@ function getMarkersCallback(directionsResponse, queryResults) {
         directionsResponse.routes[0].legs[0]['marker_count'] = 0;
         generateDirectionsPanel(directionsResponse);
     }
-}
-
-// Function to get sorted coordinate boundaries from the Directions route callback.
-function getBounds(data) {
-    var coordinateBounds = {};
-
-    // Sort lats and lons so that the query can have greater than/less than values.
-    // Apply a special compareFunction so that negative numbers are sorted properly.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-    coordinateBounds['lats'] = [data.getSouthWest().lat(), data.getNorthEast().lat()].sort(compareNumbers);
-    coordinateBounds['lons'] = [data.getSouthWest().lng(), data.getNorthEast().lng()].sort(compareNumbers);
-
-    return coordinateBounds;
 }
 
 


### PR DESCRIPTION
Made a few changes:
1) queries are now limited to coordinates that fall within the bounds of the map, so it's not pulling all DB records.
2) Markers only refresh data when the user drags the map, searches for a new location, or zooms out. 
3) Google Maps has different zoom levels: from 0-20. 0 is a global level and 20 is building level. So, I've set it up so we only do queries for certain map levels. (Basically, anything below county/region.)

Let me know if you have questions. Thanks!
